### PR TITLE
Add xxHash support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyzstd
 tqdm
 nbtlib
+xxhash


### PR DESCRIPTION
Add xxHash support to Linear.
This change is completely backwards and forwards compatible, as the field used to be ignored, and a check is in place to explicitly support pre-xxHash files.